### PR TITLE
Fix Java 8 detection

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ jobs:
           command: npm ci
       - run:
           name: Testing
-          command: npm run test
+          command: npm run test:debug
 
   # JDK 9 Node 12
   debian-jdk-9-node-12:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [2.2.3] 2020-09-05
+
+- Fix Java 8 detection ([#101@npm-groovy-lint](https://github.com/nvuillam/npm-groovy-lint/issues/101))
+
 ## [2.2.0] 2020-08-29
 
 - Fix CLASSPATH on windows in case there are spaces in paths

--- a/README.md
+++ b/README.md
@@ -142,6 +142,10 @@ Please follow [Contribution instructions](https://github.com/nvuillam/node-java-
 
 ## RELEASE NOTES
 
+### [2.2.3] 2020-09-05
+
+- Fix Java 8 detection ([#101@npm-groovy-lint](https://github.com/nvuillam/npm-groovy-lint/issues/101))
+
 ### [2.2.0] 2020-08-29
 
 - Fix CLASSPATH on windows in case there are spaces in paths

--- a/lib/java-caller.js
+++ b/lib/java-caller.js
@@ -270,7 +270,11 @@ class JavaCaller {
                 }
             }
             versionStr = versionStr.replace("_", "");
-            const versionNb = parseFloat(versionStr);
+            let versionNb = parseFloat(versionStr);
+            if (versionNb < 2) {
+                versionStr = versionStr.substring(2);
+                versionNb = parseFloat(versionStr[0] + "." + versionStr.substring(2));
+            }
             debug(`Found default java version ${versionNb}`);
             return versionNb;
         } catch (e) {


### PR DESCRIPTION
- Fix Java 8 detection ([#101@npm-groovy-lint](https://github.com/nvuillam/npm-groovy-lint/issues/101))