### PR TITLE
Support absolute paths in the classPaths. Support classPath string arrays.

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -1,0 +1,36 @@
+{
+    "ignorePaths": [
+        "**/node_modules/**",
+        "**/vscode-extension/**",
+        "**/.git/**",
+        ".vscode",
+        "package-lock.json",
+        "report"
+    ],
+    "language": "en",
+    "version": "0.1",
+    "words": [
+        "CLASSPATH",
+        "Classpath",
+        "Perso",
+        "SIGINT",
+        "classpath",
+        "classpaths",
+        "codecov",
+        "customarg",
+        "javacaller",
+        "markdownlint",
+        "myfolder",
+        "myjar",
+        "nawak",
+        "nico",
+        "nimpor",
+        "njre",
+        "nvuillam",
+        "quoi",
+        "runned",
+        "someflag",
+        "someflagwithvalue",
+        "unhack"
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -40,17 +40,19 @@ const {status, stdout, stderr} = java.run(JAVA_ARGUMENTS,JAVA_CALLER_RUN_OPTIONS
 
 ### JAVA_CALLER_OPTIONS
 
-| Parameter          | Description                                                                                                                                                           | Default value        | Example                                  |
-|--------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------|------------------------------------------|
-| jar                | Path to executable jar file                                                                                                                                           |                      | `"myfolder/myjar.jar"`                   |
-| classPath          | If jar parameter is not set, classpath to use<br/>Use `:` as separator (it will be converted if runned on Windows)                                                    | `.` (current folder) | `"java/myJar.jar:java/myOtherJar.jar"`   |
-| mainClass          | If classPath set, main class to call                                                                                                                                  |                      | `"com.example.MyClass"`                  |
-| rootPath           | If classPath elements are not relative to the current folder, you can define a root path. <br/> You may use `__dirname` if you classes / jars are in your module folder    | `.` (current folder) | `"/home/my/folder/containing/jars"`      |
-| minimumJavaVersion | Minimum java version to be used to call java command.<br/> If the java version found on machine is lower, java-caller will try to install and use the appropriate one | `8`                | `11`                                     |
-| maximumJavaVersion | Maximum java version to be used to call java command.<br/> If the java version found on machine is upper, java-caller will try to install and use the appropriate one <br/> Can be equal to minimumJavaVersion |                      | `10`                                     |
-| javaType           | jre or jdk (if not defined and installation is required, jre will be installed)                                                                       |                      | `"jre"` |
-| additionalJavaArgs | Additional parameters for JVM that will be added in every JavaCaller instance runs                                                                                                                                        |                      | `["-Xms256m","-Xmx2048m"]`                |
-| javaExecutable     | You can force to use a defined java executable, instead of letting java-caller find/install one                                                                       |                      | `"/home/some-java-version/bin/java.exe"` |
+| Parameter             | Description                                                                                                                                                                                                    | Default value        | Example                                  |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- | ---------------------------------------- |
+| jar                   | Path to executable jar file                                                                                                                                                                                    |                      | `"myfolder/myjar.jar"`                   |
+| classPath             | If jar parameter is not set, classpath to use<br/>Use `:` as separator (it will be converted if runned on Windows), or use a string array.                                                                     | `.` (current folder) | `"java/myJar.jar:java/myOtherJar.jar"`   |
+| useAbsoluteClassPaths | Set to true if classpaths should not be based on the rootPath                                                                                                                                                  | `false`              | `true`                                   |
+| mainClass             | If classPath set, main class to call                                                                                                                                                                           |                      | `"com.example.MyClass"`                  |
+| rootPath              | If classPath elements are not relative to the current folder, you can define a root path. <br/> You may use `__dirname` if you classes / jars are in your module folder                                        | `.` (current folder) | `"/home/my/folder/containing/jars"`      |
+| minimumJavaVersion    | Minimum java version to be used to call java command.<br/> If the java version found on machine is lower, java-caller will try to install and use the appropriate one                                          | `8`                  | `11`                                     |
+| maximumJavaVersion    | Maximum java version to be used to call java command.<br/> If the java version found on machine is upper, java-caller will try to install and use the appropriate one <br/> Can be equal to minimumJavaVersion |                      | `10`                                     |
+| javaType              | jre or jdk (if not defined and installation is required, jre will be installed)                                                                                                                                |                      | `"jre"`                                  |
+| additionalJavaArgs    | Additional parameters for JVM that will be added in every JavaCaller instance runs                                                                                                                             |                      | `["-Xms256m","-Xmx2048m"]`               |
+| javaExecutable        | You can force to use a defined java executable, instead of letting java-caller find/install one                                                                                                                |                      | `"/home/some-java-version/bin/java.exe"` |
+
 
 ### JAVA_ARGUMENTS
 
@@ -76,6 +78,16 @@ Call a class located in classpath
 ```javascript
 const java = new JavaCaller({
     classPath: 'test/java/dist',
+    mainClass: 'com.nvuillam.javacaller.JavaCallerTester'
+});
+const { status, stdout, stderr } = await java.run();
+```
+
+Call a class with multiple folders in the classPath
+
+```javascript
+const java = new JavaCaller({
+    classPath: ['C:\\pathA\\test\\java\\dist', 'C:\\pathB\\test\\java\\dist'],
     mainClass: 'com.nvuillam.javacaller.JavaCallerTester'
 });
 const { status, stdout, stderr } = await java.run();

--- a/README.md
+++ b/README.md
@@ -1,13 +1,12 @@
 <!-- markdownlint-disable MD033 -->
 # Java Caller for Node.js
 
-[![Version](https://img.shields.io/npm/v/java-caller.svg)](https://npmjs.org/package/node-java-caller)
+[![Version](https://img.shields.io/npm/v/java-caller.svg)](https://www.npmjs.com/package/java-caller)
 [![Downloads/week](https://img.shields.io/npm/dw/java-caller.svg)](https://npmjs.org/package/java-caller)
 [![Downloads/total](https://img.shields.io/npm/dt/java-caller.svg)](https://npmjs.org/package/java-caller)
 [![CircleCI](https://circleci.com/gh/nvuillam/node-java-caller/tree/master.svg?style=shield)](https://circleci.com/gh/nvuillam/node-java-caller/tree/master)
 [![Mega-Linter](https://github.com/nvuillam/node-java-caller/workflows/Mega-Linter/badge.svg)](https://github.com/nvuillam/mega-linter#readme)
 [![codecov](https://codecov.io/gh/nvuillam/node-java-caller/branch/master/graph/badge.svg)](https://codecov.io/gh/nvuillam/node-java-caller)
-[![Codacy Badge](https://app.codacy.com/project/badge/Grade/2f74d43c38764caab0c6f76a7a668df3)](https://www.codacy.com/manual/nvuillam/node-java-caller?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=nvuillam/node-java-caller&amp;utm_campaign=Badge_Grade)
 [![GitHub contributors](https://img.shields.io/github/contributors/nvuillam/node-java-caller.svg)](https://gitHub.com/nvuillam/node-java-caller/graphs/contributors/)
 [![GitHub stars](https://img.shields.io/github/stars/nvuillam/node-java-caller?label=Star&maxAge=2592000)](https://GitHub.com/nvuillam/node-java-caller/stargazers/)
 [![License](https://img.shields.io/npm/l/java-caller.svg)](https://github.com/nvuillam/node-java-caller/blob/master/LICENSE)

--- a/lib/java-caller.js
+++ b/lib/java-caller.js
@@ -89,7 +89,7 @@ class JavaCaller {
         let stdout = "";
         let stderr = "";
         let child;
-        const prom = new Promise(resolve => {
+        const prom = new Promise((resolve) => {
             // Spawn java command line
             debug(`Java command: ${javaExe} ${javaArgs.join(" ")}`);
             const spawnOptions = {
@@ -98,7 +98,7 @@ class JavaCaller {
                 env: Object.assign({}, process.env),
                 stdio: this.output === "console" ? "inherit" : runOptions.detached ? "ignore" : "pipe",
                 windowsHide: true,
-                windowsVerbatimArguments: true
+                windowsVerbatimArguments: true,
             };
             if (javaExe.includes(" ")) {
                 spawnOptions.shell = true;
@@ -107,23 +107,23 @@ class JavaCaller {
 
             // Gather stdout and stderr if they must be returned
             if (spawnOptions.stdio === "pipe") {
-                child.stdout.on("data", data => {
+                child.stdout.on("data", (data) => {
                     stdout += data;
                 });
-                child.stderr.on("data", data => {
+                child.stderr.on("data", (data) => {
                     stderr += data;
                 });
             }
 
             // Catch error
-            child.on("error", data => {
+            child.on("error", (data) => {
                 this.status = 666;
                 stderr += "Java spawn error: " + data;
                 resolve();
             });
 
             // Catch status code
-            child.on("close", code => {
+            child.on("close", (code) => {
                 this.status = code;
                 resolve();
             });
@@ -136,7 +136,7 @@ class JavaCaller {
 
         if (runOptions.detached) {
             // Detached mode: Just wait a little amount of time in case you want to check a command error
-            await new Promise(resolve =>
+            await new Promise((resolve) =>
                 setTimeout(() => {
                     resolve();
                 }, runOptions.waitForErrorMs)
@@ -150,7 +150,7 @@ class JavaCaller {
         const result = {
             status: this.status,
             stdout: stdout,
-            stderr: stderr
+            stderr: stderr,
         };
         if (child) {
             result.childJavaProcess = child;
@@ -165,20 +165,19 @@ class JavaCaller {
 
     // Translate the classpath from a string or string array into a string
     buildClasspathStr() {
+        let classPathList = [];
 
-      let classPathList = [];
+        if (typeof this.classPath === "string") {
+            classPathList = this.classPath.split(":");
+        } else {
+            classPathList = this.classPath;
+        }
 
-      if (typeof(this.classPath) === "string") {
-        classPathList = this.classPath.split(":");
-      } else {
-        classPathList = this.classPath;
-      }
+        if (!this.useAbsoluteClassPaths) {
+            classPathList = classPathList.map((classPathElt) => path.resolve(this.rootPath + path.sep + classPathElt));
+        }
 
-      if (!this.useAbsoluteClassPaths) {
-        classPathList = classPathList.map(classPathElt => path.resolve(this.rootPath + path.sep + classPathElt));
-      }
-
-      return classPathList.join(path.delimiter);
+        return classPathList.join(path.delimiter);
     }
 
     // Set first java arguments, then jar || classpath, then jar/class user arguments
@@ -239,7 +238,7 @@ class JavaCaller {
                 const packageJsonContent = {
                     name: "java-caller-support",
                     version: "1.0.0",
-                    description: "Java installations by java-caller (https://github.com/nvuillam/node-java-caller)"
+                    description: "Java installations by java-caller (https://github.com/nvuillam/node-java-caller)",
                 };
                 await fse.writeFile(packageJson, JSON.stringify(packageJsonContent), "utf8");
             }
@@ -310,7 +309,7 @@ class JavaCaller {
             const dirContent = await fse.readdir(javaInstallsTopDir);
             let cacheFutureItem;
             let isFirst = true;
-            const dirContentFiltered = dirContent.filter(file => {
+            const dirContentFiltered = dirContent.filter((file) => {
                 if (!fse.statSync(path.join(javaInstallsTopDir, file)).isDirectory()) {
                     return false;
                 }

--- a/lib/java-caller.js
+++ b/lib/java-caller.js
@@ -16,6 +16,7 @@ class JavaCaller {
 
     jar;
     classPath = ".";
+    useAbsoluteClassPaths = false;
     mainClass;
     output = "none"; // can be none or console
     status = null;
@@ -34,7 +35,8 @@ class JavaCaller {
      * Creates a JavaCaller instance
      * @param {object} [opts] - Run options
      * @param {string} [opts.jar] - Path to executable jar file
-     * @param {string} [opts.classPath] - If jar parameter is not set, classpath to use. Use : as separator (it will be converted if runned on Windows)
+     * @param {string | string[]} [opts.classPath] - If jar parameter is not set, classpath to use. Use : as separator (it will be converted if runned on Windows)
+     * @param {boolean} [opts.useAbsoluteClassPaths] - Set to true if classpaths should not be based on the rootPath.
      * @param {string} [opts.mainClass] - If classPath set, main class to call
      * @param {number} [opts.minimumJavaVersion] - Minimum java version to be used to call java command. If the java version found on machine is lower, java-caller will try to install and use the appropriate one
      * @param {number} [opts.maximumJavaVersion] - Maximum java version to be used to call java command. If the java version found on machine is upper, java-caller will try to install and use the appropriate one
@@ -46,6 +48,7 @@ class JavaCaller {
     constructor(opts) {
         this.jar = opts.jar || this.jar;
         this.classPath = opts.classPath || this.classPath;
+        this.useAbsoluteClassPaths = opts.useAbsoluteClassPaths || this.useAbsoluteClassPaths;
         this.mainClass = opts.mainClass || this.mainClass;
         this.minimumJavaVersion = opts.minimumJavaVersion || this.minimumJavaVersion;
         this.maximumJavaVersion = opts.maximumJavaVersion || this.maximumJavaVersion;
@@ -80,10 +83,8 @@ class JavaCaller {
             await this.manageJavaInstall();
         }
 
-        const classPathStr = this.classPath
-            .split(":")
-            .map(classPathElt => path.resolve(this.rootPath + path.sep + classPathElt))
-            .join(path.delimiter);
+        const classPathStr = this.buildClasspathStr();
+
         const javaArgs = this.buildArguments(classPathStr, (userArguments || []).concat(this.additionalJavaArgs));
         let stdout = "";
         let stderr = "";
@@ -160,6 +161,24 @@ class JavaCaller {
         process.env["JAVA_HOME"] = this.prevJavaHome || process.env["JAVA_HOME"];
 
         return result;
+    }
+
+    // Translate the classpath from a string or string array into a string
+    buildClasspathStr() {
+
+      let classPathList = [];
+
+      if (typeof(this.classPath) === "string") {
+        classPathList = this.classPath.split(":");
+      } else {
+        classPathList = this.classPath;
+      }
+
+      if (!this.useAbsoluteClassPaths) {
+        classPathList = classPathList.map(classPathElt => path.resolve(this.rootPath + path.sep + classPathElt));
+      }
+
+      return classPathList.join(path.delimiter);
     }
 
     // Set first java arguments, then jar || classpath, then jar/class user arguments

--- a/lib/java-caller.js
+++ b/lib/java-caller.js
@@ -35,8 +35,8 @@ class JavaCaller {
      * Creates a JavaCaller instance
      * @param {object} [opts] - Run options
      * @param {string} [opts.jar] - Path to executable jar file
-     * @param {string | string[]} [opts.classPath] - If jar parameter is not set, classpath to use. Use : as separator (it will be converted if runned on Windows)
-     * @param {boolean} [opts.useAbsoluteClassPaths] - Set to true if classpaths should not be based on the rootPath.
+     * @param {string | string[]} [opts.classPath] - If jar parameter is not set, classpath to use. Use : as separator (it will be converted if runned on Windows), or use a string array
+     * @param {boolean} [opts.useAbsoluteClassPaths] - Set to true if classpaths should not be based on the rootPath
      * @param {string} [opts.mainClass] - If classPath set, main class to call
      * @param {number} [opts.minimumJavaVersion] - Minimum java version to be used to call java command. If the java version found on machine is lower, java-caller will try to install and use the appropriate one
      * @param {number} [opts.maximumJavaVersion] - Maximum java version to be used to call java command. If the java version found on machine is upper, java-caller will try to install and use the appropriate one

--- a/lib/java-caller.js
+++ b/lib/java-caller.js
@@ -76,7 +76,7 @@ class JavaCaller {
 
         let javaExe = this.javaExecutable;
         if (javaExe.toLowerCase().includes(".exe") && !javaExe.includes(`'`)) {
-            // Java executable has been overriden by caller : use it
+            // Java executable has been overridden by caller : use it
             javaExe = `"${path.resolve(javaExe)}"`;
         } else {
             // Check if matching java version is present, install and update PATH if it is not

--- a/test/java-caller.test.js
+++ b/test/java-caller.test.js
@@ -36,12 +36,35 @@ describe("Call with classes", () => {
         checkStatus(0, status, stdout, stderr);
     });
 
+    it("should call JavaCallerTester.class with a classPath array", async () => {
+        const java = new JavaCaller({
+            classPath: ['test/java/dist'],
+            mainClass: 'com.nvuillam.javacaller.JavaCallerTester'
+        });
+        const { status, stdout, stderr } = await java.run();
+
+        checkStatus(0, status, stdout, stderr);
+        checkStdOutIncludes(`JavaCallerTester is called !`, stdout, stderr);
+    });
+
+    it("should call JavaCallerTester.class with absolute classpaths", async () => {
+        const java = new JavaCaller({
+            classPath: __dirname + '/java/dist',
+            useAbsoluteClassPaths: true,
+            mainClass: 'com.nvuillam.javacaller.JavaCallerTester'
+        });
+        const { status, stdout, stderr } = await java.run();
+
+        checkStatus(0, status, stdout, stderr);
+        checkStdOutIncludes(`JavaCallerTester is called !`, stdout, stderr);
+    });
+
     it("should use call JavaCallerTester.class with java and custom arguments", async () => {
         const java = new JavaCaller({
             classPath: 'test/java/dist',
             mainClass: 'com.nvuillam.javacaller.JavaCallerTester'
         });
-        const { status, stdout, stderr } = await java.run(['-Xms256m', '-Xmx2048m', '-customarg nico']);
+        const { status, stdout, stderr } = await java.run(['-Xms256m', '-Xmx1024m', '-customarg nico']);
 
         checkStatus(0, status, stdout, stderr);
         checkStdOutIncludes(`JavaCallerTester is called !`, stdout, stderr);
@@ -120,4 +143,3 @@ describe("Call with classes", () => {
     });
 
 });
-


### PR DESCRIPTION
This pull request makes two changes to solve an issue I was having while including node-java-caller in one of my libraries.

First, **a new parameter is added to `JAVA_CALLER_OPTIONS` called `useAbsoluteClassPaths`**.  To preserve the existing behaviour, it defaults to `false`. When `true`, the paths in the `classPath` are taken as they are without prepending the `rootPath` to the beginning.

Second, **multiple classPaths can be optionally specified in a string array**, rather than a string with the `:` separator.  This helps when multiple absolute paths are used in a Windows environment.  Without it, the `:` after the drive letter is treated as a separate path.