### PR TITLE
Fix using --javaexecutable in Linux

### DIFF
--- a/lib/java-caller.js
+++ b/lib/java-caller.js
@@ -81,7 +81,7 @@ class JavaCaller {
         if (javaExe.toLowerCase().includes(".exe") && !javaExe.includes(`'`)) {
             // Java executable has been overridden by caller : use it
             javaExe = `"${path.resolve(javaExe)}"`;
-        } else {
+        } else if (javaExe === "java") {
             // Check if matching java version is present, install and update PATH if it is not
             await this.manageJavaInstall();
         }


### PR DESCRIPTION
There is a restriction on --javaexecutable usage for platforms other than Windows, due to logic checking for usage of '.exe'. To allow other platforms to specify their java executable and skip the version detection the way Windows can, adjust the condition for the version check.

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Exposes an easy workaround for #18

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Use of --javaexecutable to bypass the version detection is possible with windows, but not in platforms where java binary is not named java.exe. Adjust the conditions so that version detection and autodownload can be skipped when a user passes in an explicit java binary they want to use. 
2. Ultimately want to be able to use this change with npm-groovy-lint

## Readiness Checklist

### Author/Contributor
- [x] Add entry to the **CHANGELOG.md** listing the change and linking to the corresponding issue (if appropriate)
- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
