### PR TITLE
Feature/semver based version

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -14,6 +14,7 @@
         "CLASSPATH",
         "Classpath",
         "Gowans",
+        "KICS",
         "PROSELINT",
         "Perso",
         "SIGINT",

--- a/.github/workflows/mega-linter.yml
+++ b/.github/workflows/mega-linter.yml
@@ -36,12 +36,12 @@ jobs:
           # https://github.com/oxsecurity/megalinter#configuration
           VALIDATE_ALL_CODEBASE: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          DISABLE_LINTERS: JAVASCRIPT_STANDARD,SPELL_PROSELINT
+          DISABLE_LINTERS: JAVASCRIPT_STANDARD,SPELL_PROSELINT,REPOSITORY_KICS
           JAVA_FILTER_REGEX_EXCLUDE: (JavaCallerTester)
 
       # Upload Mega-Linter artifacts. They will be available on Github action page "Artifacts" section
       - name: Archive production artifacts
-        if: ${{ success() }} || ${{ failure() }}
+        if: success() || failure()
         uses: actions/upload-artifact@v3
         with:
           name: Mega-Linter reports

--- a/lib/java-caller.js
+++ b/lib/java-caller.js
@@ -6,6 +6,7 @@ const path = require("path");
 const { spawn } = require("child_process");
 const util = require("util");
 const execPromise = util.promisify(require("child_process").exec);
+const semver = require("semver");
 
 class JavaCaller {
     "use strict";
@@ -213,8 +214,10 @@ class JavaCaller {
         if (await this.getInstallInCache()) {
             return;
         }
+        const semverRule = `>=${this.minimumJavaVersion}.0.0` + (this.maximumJavaVersion ? ` <${this.maximumJavaVersion}.0.0` : '');
         const javaVersion = await this.getJavaVersion();
-        if (javaVersion === false || javaVersion < this.minimumJavaVersion || (this.maximumJavaVersion && javaVersion > this.maximumJavaVersion)) {
+        const requiresInstall = javaVersion === false ? true : !semver.satisfies(javaVersion, semverRule)
+        if (requiresInstall) {
             // Check if the appropriate version has already been installed
             const { javaVersionHome = null, javaVersionBin = null } = await this.findJavaVersionHome();
             if (javaVersionHome) {
@@ -283,24 +286,16 @@ class JavaCaller {
         try {
             const { stderr } = await execPromise("java -version");
             const match = /version "(.*?)"/.exec(stderr);
-            const parts = match[1].split(".");
-            let join = ".";
-            let versionStr = "";
-            for (const v of parts) {
-                versionStr += v;
-                if (join !== null) {
-                    versionStr += join;
-                    join = null;
-                }
+
+            // see https://openjdk.org/jeps/223
+            // semver.coerce does awfully good job of parsing anythin Java throws our way
+            const version = semver.valid(semver.coerce(match[1]))
+            if (version === null) {
+                throw new Error(`unparseable java version: ${match[1]}`)
             }
-            versionStr = versionStr.replace("_", "");
-            let versionNb = parseFloat(versionStr);
-            if (versionNb < 2) {
-                versionStr = versionStr.substring(2);
-                versionNb = parseFloat(versionStr[0] + "." + versionStr.substring(2));
-            }
-            debug(`Found default java version ${versionNb}`);
-            return versionNb;
+
+            debug(`Found default java version ${version}`);
+            return version;
         } catch (e) {
             debug(`Java not found: ${e.message}`);
             return false;
@@ -310,41 +305,44 @@ class JavaCaller {
     // Browse locally installed java versions
     // check if one matches with javaType , minimumJavaVersion and maximumJavaVersion
     async findJavaVersionHome() {
-        let javaInstallsTopDir = this.javaCallerSupportDir + path.sep + "jre";
-        if (fse.existsSync(javaInstallsTopDir)) {
-            const dirContent = await fse.readdir(javaInstallsTopDir);
-            let cacheFutureItem;
-            let isFirst = true;
-            const dirContentFiltered = dirContent.filter((file) => {
-                if (!fse.statSync(path.join(javaInstallsTopDir, file)).isDirectory()) {
-                    return false;
-                }
-                const versionMatches = file.includes("u")
-                    ? file.substring(0, file.indexOf("u")).match(/(\d+)/)
-                    : file.substring(0, file.indexOf(".")).match(/(\d+)/);
-                const versionFound = parseInt(versionMatches[0], 10);
-                const isMatching = this.checkMatchingJavaVersion(versionFound, file);
-                if (isMatching && isFirst) {
-                    cacheFutureItem = { versionFound, file };
-                    isFirst = false;
-                }
-                return isMatching;
-            });
-            if (dirContentFiltered[0]) {
-                const javaVersionHome = javaInstallsTopDir + path.sep + dirContentFiltered[0];
-                const javaVersionBin = javaVersionHome + path.sep + this.getPlatformBinPath();
-                if (fse.existsSync(javaVersionBin)) {
-                    debug(
-                        `Found matching java bin: ${javaVersionBin} for ${this.javaType ? this.javaType : "jre or jdk"} ${this.minimumJavaVersion}${
-                            this.maximumJavaVersion && this.maximumJavaVersion !== this.minimumJavaVersion ? " -> " + this.maximumJavaVersion : "+"
-                        }`
-                    );
-                    this.addInCache(cacheFutureItem.versionFound, cacheFutureItem.file, javaVersionHome, javaVersionBin);
-                    return { javaVersionHome, javaVersionBin };
-                }
-            }
+        const javaInstallsTopDir = path.join(this.javaCallerSupportDir, "jre");
+        if (!fse.existsSync(javaInstallsTopDir)) {
+            return {};
         }
-        return {};
+
+        return await fse.readdir(javaInstallsTopDir)
+            .then((items) =>
+                items
+                .filter((item) => fse.statSync(path.join(javaInstallsTopDir, item)).isDirectory())
+                .map((folder) => {
+                    const version = semver.valid(semver.coerce(folder))
+                    return { version, folder }
+                })
+                .filter(({ version, folder }) => this.checkMatchingJavaVersion(version.major, folder))
+                .map(({ version, folder }) => {
+                    const home = path.join(javaInstallsTopDir, folder);
+                    const bin = path.join(home, this.getPlatformBinPath());
+                    return { version, folder, home, bin }
+                })
+                .find(({ bin }) => fse.existsSync(bin))
+            )
+            .then((match) => {
+                if (!match) return {};
+                const { version, folder, home, bin } = match
+
+                debug(
+                    `Found matching java bin: ${bin} for ${this.javaType ? this.javaType : "jre or jdk"} ${this.minimumJavaVersion}${
+                        this.maximumJavaVersion && this.maximumJavaVersion !== this.minimumJavaVersion ? " -> " + this.maximumJavaVersion : "+"
+                    }`
+                );
+                this.addInCache(version.major, folder, home, bin);
+
+                return { home, bin };
+            })
+            .catch((e) => {
+                debug(`findJavaVersionHome failed: ${e}`)
+                return {}
+            })
     }
 
     checkMatchingJavaVersion(versionFound, file) {

--- a/lib/java-caller.js
+++ b/lib/java-caller.js
@@ -257,7 +257,7 @@ class JavaCaller {
             const njreOptions = { type: javaTypeToInstall };
             const prevRequireMainFilename = require.main.filename; // hack require.main.filename to njre installs java where we want
             require.main.filename = packageJson;
-            const installDir = await njre.install(this.maximumJavaVersion || this.minimumJavaVersion, njreOptions);
+            const installDir = await njre.install(javaVersionToInstall, njreOptions);
             require.main.filename = prevRequireMainFilename; // unhack require.main.filename
             console.log(`Installed Java ${javaTypeToInstall} ${javaVersionToInstall} in ${installDir}...`);
 
@@ -315,7 +315,7 @@ class JavaCaller {
                 items
                 .filter((item) => fse.statSync(path.join(javaInstallsTopDir, item)).isDirectory())
                 .map((folder) => {
-                    const version = semver.valid(semver.coerce(folder))
+                    const version = semver.coerce(folder)
                     return { version, folder }
                 })
                 .filter(({ version, folder }) => this.checkMatchingJavaVersion(version.major, folder))
@@ -337,7 +337,7 @@ class JavaCaller {
                 );
                 this.addInCache(version.major, folder, home, bin);
 
-                return { home, bin };
+                return { javaVersionHome: home, javaVersionBin: bin };
             })
             .catch((e) => {
                 debug(`findJavaVersionHome failed: ${e}`)

--- a/lib/java-caller.js
+++ b/lib/java-caller.js
@@ -288,10 +288,10 @@ class JavaCaller {
             const match = /version "(.*?)"/.exec(stderr);
 
             // see https://openjdk.org/jeps/223
-            // semver.coerce does awfully good job of parsing anythin Java throws our way
+            // semver.coerce does awfully good job of parsing anything Java throws our way
             const version = semver.valid(semver.coerce(match[1]))
             if (version === null) {
-                throw new Error(`unparseable java version: ${match[1]}`)
+                throw new Error(`unparsable java version: ${match[1]}`)
             }
 
             debug(`Found default java version ${version}`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "debug": "^4.3.4",
         "fs-extra": "^11.1.1",
-        "njre": "^1.0.0"
+        "njre": "^1.0.0",
+        "semver": "^7.5.4"
       },
       "devDependencies": {
         "@babel/eslint-parser": "^7.22.15",
@@ -98,6 +99,15 @@
         "url": "https://opencollective.com/babel"
       }
     },
+    "node_modules/@babel/core/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/@babel/eslint-parser": {
       "version": "7.22.15",
       "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.22.15.tgz",
@@ -114,6 +124,15 @@
       "peerDependencies": {
         "@babel/core": "^7.11.0",
         "eslint": "^7.5.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@babel/eslint-parser/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/generator": {
@@ -161,6 +180,15 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/@babel/helper-environment-visitor": {
@@ -2058,6 +2086,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/istanbul-lib-instrument/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
     "node_modules/istanbul-lib-processinfo": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/istanbul-lib-processinfo/-/istanbul-lib-processinfo-2.0.3.tgz",
@@ -2328,6 +2365,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/lru-cache/node_modules/yallist": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+    },
     "node_modules/make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -2341,6 +2394,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
       }
     },
     "node_modules/minimatch": {
@@ -3194,12 +3256,17 @@
       ]
     },
     "node_modules/semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true,
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
       "bin": {
         "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/serialize-javascript": {
@@ -3801,6 +3868,14 @@
         "gensync": "^1.0.0-beta.2",
         "json5": "^2.2.1",
         "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+          "dev": true
+        }
       }
     },
     "@babel/eslint-parser": {
@@ -3812,6 +3887,14 @@
         "@nicolo-ribaudo/eslint-scope-5-internals": "5.1.1-v1",
         "eslint-visitor-keys": "^2.1.0",
         "semver": "^6.3.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+          "dev": true
+        }
       }
     },
     "@babel/generator": {
@@ -3849,6 +3932,14 @@
         "@babel/helper-validator-option": "^7.18.6",
         "browserslist": "^4.21.3",
         "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+          "dev": true
+        }
       }
     },
     "@babel/helper-environment-visitor": {
@@ -5234,6 +5325,14 @@
         "@istanbuljs/schema": "^0.1.2",
         "istanbul-lib-coverage": "^3.0.0",
         "semver": "^6.3.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+          "dev": true
+        }
       }
     },
     "istanbul-lib-processinfo": {
@@ -5439,6 +5538,21 @@
         }
       }
     },
+    "lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "requires": {
+        "yallist": "^4.0.0"
+      },
+      "dependencies": {
+        "yallist": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+          "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+        }
+      }
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -5446,6 +5560,14 @@
       "dev": true,
       "requires": {
         "semver": "^6.0.0"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "6.3.1",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+          "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+          "dev": true
+        }
       }
     },
     "minimatch": {
@@ -6060,10 +6182,12 @@
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "semver": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
-      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
-      "dev": true
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
+      "requires": {
+        "lru-cache": "^6.0.0"
+      }
     },
     "serialize-javascript": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
   "dependencies": {
     "debug": "^4.3.4",
     "fs-extra": "^11.1.1",
-    "njre": "^1.0.0"
+    "njre": "^1.0.0",
+    "semver": "^7.5.4"
   },
   "devDependencies": {
     "@babel/eslint-parser": "^7.22.15",


### PR DESCRIPTION
<!-- markdownlint-disable -->

Hopefully Fixes #41 

<!-- markdownlint-restore -->

## Proposed Changes

1. using `semver.coerce` in `getJavaVersion`
2. using `semver.satisfies`-based comparison instead of float compare to eliminate '17.09' problem
3. subjectively cleaner version of `findJavaVersionHome` 

Testing on non-mac platforms is required. 