### PR TITLE
fix semver rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 Lightweight cross-platform javascript module to **easily call java commands from Node.js sources**.
 
 - **Automatically installs required Java version** if not present on the system
-- Compliant with **JDK & JRE** from **8 to 14**
+- Compliant with **JDK & JRE** from **8 to 20**
 - Uses node [spawn](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options) method to perform the call
 
 There are two ways to use java-caller:

--- a/lib/java-caller.js
+++ b/lib/java-caller.js
@@ -218,7 +218,7 @@ class JavaCaller {
         if (this.minimumJavaVersion === this.maximumJavaVersion) {
             semverRule = `=${this.minimumJavaVersion}.x.x`;
         } else {
-            semverRule = `>=${this.minimumJavaVersion}.0.0` + (this.maximumJavaVersion ? ` <${this.maximumJavaVersion}.0.0` : '');
+            semverRule = `>=${this.minimumJavaVersion}.0.0` + (this.maximumJavaVersion ? ` <=${this.maximumJavaVersion}.x.x` : '');
         }
         const javaVersion = await this.getJavaVersion();
         const requiresInstall = javaVersion === false ? true : !semver.satisfies(javaVersion, semverRule)

--- a/lib/java-caller.js
+++ b/lib/java-caller.js
@@ -214,7 +214,12 @@ class JavaCaller {
         if (await this.getInstallInCache()) {
             return;
         }
-        const semverRule = `>=${this.minimumJavaVersion}.0.0` + (this.maximumJavaVersion ? ` <${this.maximumJavaVersion}.0.0` : '');
+        let semverRule = ''
+        if (this.minimumJavaVersion === this.maximumJavaVersion) {
+            semverRule = `=${this.minimumJavaVersion}.x.x`;
+        } else {
+            semverRule = `>=${this.minimumJavaVersion}.0.0` + (this.maximumJavaVersion ? ` <${this.maximumJavaVersion}.0.0` : '');
+        }
         const javaVersion = await this.getJavaVersion();
         const requiresInstall = javaVersion === false ? true : !semver.satisfies(javaVersion, semverRule)
         if (requiresInstall) {


### PR DESCRIPTION
Following introduction of semver in #42, this PR is to fix couple of issues in the rule used to detect if desired java version is installed or not

Hopefully fixes nvuillam/npm-groovy-lint#321

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Handle case where minimumJavaVersion and maximumJavaversion are set with same values (like `npm-groovy-lint`)
2. Fix regression as maximumJavaVersion is supposed to be included not excluded

## Readiness Checklist

### Author/Contributor
- [ ] Add entry to the **CHANGELOG.md** listing the change and linking to the corresponding issue (if appropriate)
- [ ] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
