### PR TITLE
Addition of windowless (javaw) option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add option for using javaw instead of java on run for Windows, by [@SotirisVas](https://github.com/SotirisVas) in [#65](https://github.com/nvuillam/node-java-caller/issues/65)
+
 ## [3.2.0] 2023-11-26
 
 - Upgrade njre to v1.1.0 (now handles Mac M1)

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Example: `["-Xms256m", "--someflagwithvalue myVal", "-c"]`
 | [cwd](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options) | You can override cwd of spawn called by JavaCaller runner | `process.cwd()` | `some/other/cwd/folder` |
 | javaArgs | List of arguments for JVM only, not the JAR or the class | `[]` | `['--add-opens=java.base/java.lang=ALL-UNNAMED']` |
 | [windowsVerbatimArguments](https://nodejs.org/api/child_process.html#child_process_child_process_spawn_command_args_options) | No quoting or escaping of arguments is done on Windows. Ignored on Unix. This is set to true automatically when shell is specified and is CMD. | `true` | `false` |
+| [windowless](https://docs.oracle.com/en/java/javase/17/docs/specs/man/java.html#:~:text=main()%20method.-,javaw,information%20if%20a%20launch%20fails.) | If windowless is true, JavaCaller calls javaw instead of java to not create any windows, useful when using detached on Windows. Ignored on Unix. | false | true
 
 ## Examples
 
@@ -135,6 +136,16 @@ const { status, stdout, stderr, childJavaProcess } = await java.run(['--sleep'],
 
 // Kill later the java process if necessary
 childJavaProcess.kill('SIGINT');
+```
+
+Call a windowless java process
+
+```javascript
+const java = new JavaCaller({
+    classPath: 'test/java/dist',
+    mainClass: 'com.nvuillam.javacaller.JavaCallerTester'
+});
+const { status, stdout, stderr } = await java.run(['--sleep'], { windowless: true });
 ```
 
 You can see **more examples in** [**test methods**](https://github.com/nvuillam/node-java-caller/blob/master/test/java-caller.test.js)

--- a/lib/java-caller.js
+++ b/lib/java-caller.js
@@ -24,6 +24,7 @@ class JavaCaller {
 
     javaSupportDir;
     javaExecutable = "java";
+    javaExecutableWindowless = "javaw";
     additionalJavaArgs = [];
     commandJavaArgs = [];
 
@@ -80,13 +81,14 @@ class JavaCaller {
         runOptions.cwd = typeof runOptions.cwd === "undefined" ? process.cwd() : runOptions.cwd;
         runOptions.stdoutEncoding = typeof runOptions.stdoutEncoding === "undefined" ? "utf8" : runOptions.stdoutEncoding;
         runOptions.windowsVerbatimArguments = typeof runOptions.windowsVerbatimArguments === "undefined" ? true : runOptions.windowsVerbatimArguments;
+        runOptions.windowless = typeof runOptions.windowless === "undefined" ? false : os.platform() !== "win32" ? false : runOptions.windowless;
         this.commandJavaArgs = (runOptions.javaArgs || []).concat(this.additionalJavaArgs);
 
-        let javaExe = this.javaExecutable;
+        let javaExe = runOptions.windowless ? this.javaExecutableWindowless : this.javaExecutable;
         if (javaExe.toLowerCase().includes(".exe") && !javaExe.includes(`'`)) {
             // Java executable has been overridden by caller : use it
             javaExe = `"${path.resolve(javaExe)}"`;
-        } else if (javaExe === "java") {
+        } else if (javaExe === "java" || javaExe === "javaw") {
             // Check if matching java version is present, install and update PATH if it is not
             await this.manageJavaInstall();
         }
@@ -102,7 +104,7 @@ class JavaCaller {
             debug(`Java command: ${javaExe} ${javaArgs.join(" ")}`);
             const spawnOptions = {
                 detached: runOptions.detached,
-                cwd: javaExe === "java" ? runOptions.cwd : undefined,
+                cwd: javaExe === "java" || javaExe === "javaw" ? runOptions.cwd : undefined,
                 env: Object.assign({}, process.env),
                 stdio: this.output === "console" ? "inherit" : runOptions.detached ? "ignore" : "pipe",
                 windowsHide: true,

--- a/test/java-caller.test.js
+++ b/test/java-caller.test.js
@@ -36,6 +36,16 @@ describe("Call with classes", () => {
         checkStatus(0, status, stdout, stderr);
     });
 
+    it("should call JavaCallerTester.class using javaw", async () => {
+        const java = new JavaCaller({
+            classPath: 'test/java/dist',
+            mainClass: 'com.nvuillam.javacaller.JavaCallerTester'
+        });
+        const { status, stdout, stderr } = await java.run(['--sleep'], { windowless: true });
+        checkStatus(0, status, stdout, stderr);
+    });
+
+
     it("should call JavaCallerTester.class with proper stdout encoding", async () => {
         const java = new JavaCaller({
             classPath: 'test/java/dist',


### PR DESCRIPTION
Added a new option to call "javaw" instead of "java", only for Windows as Unix does not need this utility.

<!-- Please ensure your PR title is brief and descriptive for a good changelog entry -->
<!-- Link to issue if there is one -->
<!-- markdownlint-disable -->

Fixes #65 

<!-- markdownlint-restore -->

<!-- Describe what the changes are -->

## Proposed Changes

1. Add new option for windowless
2. If true, javaExe becomes javaw
3. Check if caller platform is actually Windows, if true then use javaw, used for cross-platform compatibility
4. Added changelog entry and documentation for the option

## Readiness Checklist

### Author/Contributor
- [X] Add entry to the **CHANGELOG.md** listing the change and linking to the corresponding issue (if appropriate)
- [X] If documentation is needed for this change, has that been included in this pull request

### Reviewing Maintainer
- [ ] Label as `breaking` if this is a large fundamental change
- [ ] Label as either `automation`, `bug`, `documentation`, `enhancement`, `infrastructure`, or `performance`
